### PR TITLE
Changed "do_add_layers" icon

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -285,7 +285,7 @@ class VIEW3D_PT_SnappyHexMeshGUI_Object(bpy.types.Panel, SnappyHexMeshGUI_ToolBa
         rowsub.label(text="Options:")
         rowsub.prop(gui, "number_of_cpus", text="CPUs:")
         rowsub.prop(gui, "do_snapping", text="", icon='UV_VERTEXSEL')
-        rowsub.prop(gui, "do_add_layers", text="", icon='HAIR')
+        rowsub.prop(gui, "do_add_layers", text="", icon='MOD_WAVE')
 
         rowsub = col.row()
         rowsub.prop(gui, "openfoam_framework")


### PR DESCRIPTION
Changed "do_add_layers" icon from 'hair' to 'mod_wave' because 'hair' is no longer a valid Blender icon as of Blender version 3.2.0